### PR TITLE
Use JSON module

### DIFF
--- a/hipchat.pl
+++ b/hipchat.pl
@@ -9,6 +9,7 @@ use warnings;
 use strict;
 use Getopt::Long;
 use LWP::UserAgent;
+use JSON;
 
 my $usage = "This script will send a notification to hipchat.\n
 \tUsage:
@@ -227,8 +228,12 @@ if ($optionAPI eq "v1")
 elsif ($optionAPI eq "v2")
 {
    $hipchat_url = "$hipchat_host\/$optionAPI\/room/$optionRoom/notification?auth_token=$optionToken";
-   $hipchat_json = "{\"color\":\"$optionColour\", \"message\":\"$optionMessage\", \"message_format\":\"$optionType\", \"notify\":$optionNotify}";
-   
+   $hipchat_json = encode_json({
+      color    => $optionColour,
+      message  => $optionMessage,
+      message_format => $optionType,
+      notify => $optionNotify,
+   });
    $request = HTTP::Request->new(POST => $hipchat_url);
    $request->content_type('application/json');
    $request->content($hipchat_json);

--- a/hipchat.pl
+++ b/hipchat.pl
@@ -63,16 +63,16 @@ $default_type          = "text";
 $message_limit         = 10000;
 
 #Get the input options.
-GetOptions( "room=s"   => \$optionRoom,
-            "token=s"  => \$optionToken,
-            "message=s"=> \$optionMessage,
-            "from=s"   => \$optionFrom,
-            "type=s"   => \$optionType,
-            "api=s"    => \$optionAPI,
-            "proxy=s"  => \$optionProxy,
-            "notify=s" => \$optionNotify,
-            "colour=s" => \$optionColour,
-            "debug=s"  => \$optionDebug);
+GetOptions( "room=s"         => \$optionRoom,
+            "token=s"        => \$optionToken,
+            "message=s"      => \$optionMessage,
+            "from=s"         => \$optionFrom,
+            "type=s"         => \$optionType,
+            "api=s"          => \$optionAPI,
+            "proxy=s"        => \$optionProxy,
+            "notify=s"       => \$optionNotify,
+            "colour|color=s" => \$optionColour,
+            "debug=s"        => \$optionDebug);
 
 ##############################
 ## VERIFY OPTIONS


### PR DESCRIPTION
I had a problem trying to post a message that contains newlines (and tabs), so I switched to using the JSON module to take care of escaping control codes.

(I started out by escaping the newlines myself; that's when I discovered the message I was trying to post had tabs, too, which made it still fail.)

While I was at it, I made it so that --color and --colour both worked the same way.

Thanks!
