### PR TITLE
Adds parameter support for private Hipchat servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,32 +5,43 @@ This is a simple perl script that will use Hipchat's API v2 to message a room af
 
 This script was developed in a CentOS 6.4 environment and has not been tested anywhere else.
 
-Sample Script Output:
-This script will send a notification to hipchat.
+Sample Script Output
+--------------------
+    This script will send a notification to hipchat.
 
-	Usage:
-		-room      Hipchat room name or ID.                      Example: '-room "test"'
-		-token     Hipchat Authentication token.                 Example: '-token"abc"'
-		-message   Message to be sent to room.                   Example: '-message"Hello World!"'
-		-type      (Optional) Hipchat message type (text|html).  Example: '-type "text"'                   (default: text)
-		-API       (Optional) Hipchat API Version. (v1|v2).      Example: '-type "v2"'                     (default: v2)
-		-notify    (Optional) Message will trigger notification. Example: '-notify "true"'                 (default: false)
-		-colour    (Optional) Message colour (y|r|g|p|g|random)  Example: '-colour "green"'                (default: yellow)
-		-from      (Optional) Name message is to be sent from.   Example: '-from "Test"'                   (only used with APIv1)
-		-proxy     (Optional) Network proxy to use.              Example: '-proxy "http://127.0.0.1:3128"'
+    Usage:
+        -room      Hipchat room name or ID.                      Example: '-room "test"'
+        -token     Hipchat Authentication token.                 Example: '-token "abc"'
+        -message   Message to be sent to room.                   Example: '-message "Hello World!"'
+        -type      (Optional) Hipchat message type (text|html).  Example: '-type "text"'                   (default: text)
+        -API       (Optional) Hipchat API Version. (v1|v2).      Example: '-type "v2"'                     (default: v2)
+        -notify    (Optional) Message will trigger notification. Example: '-notify "true"'                 (default: false)
+        -colour    (Optional) Message colour (y|r|g|p|g|random)  Example: '-colour "green"'                (default: yellow)
+        -from      (Optional) Name message is to be sent from.   Example: '-from "Test"'                   (only used with APIv1)
+        -proxy     (Optional) Network proxy to use.              Example: '-proxy "http://127.0.0.1:3128"'
+        -host      (Optional) Hipchat server to use.             Example: '-host "https://hipchat.company.net"'
 
-	Basic Example:
-		hipchat.pl -room "test" -token "abc" -message "Hello World!" 
+    Basic Example:
+        hipchat.pl -room "test" -token "abc" -message "Hello World!"
 
-	Full Example:
-		hipchat.pl -room "test" -token "abc" -message "Hello World!" -type text -api v2 -notify true -colour green -proxy http://127.0.0.1:3128
+    Full Example:
+        hipchat.pl -room "test" -token "abc" -message "Hello World!" -type text -api v2 -notify true -colour green -proxy http://127.0.0.1:3128
 
-		
-Sample Successful Call:
->$hipchat.pl -room Jenkins -token abc -message 'Hello World!' -colour green -proxy http://127.0.0.1:3128 
-Hipchat notification posted successfully.
+Environment Configuration
+-------------------------
+In addition to the command line parameters, you can also set configuration values in your environment:
 
-Sample Unsuccessful Call (bad token):
->$hipchat.pl -room Jenkins -token abd -message 'Hello World!' -colour green -proxy http://127.0.0.1:3128 
-Hipchat notification failed!
-401 Unauthorized
+    $ export HIPCHAT_TOKEN=abc
+    $ export HIPCHAT_ROOM=Jenkins
+    $ export HIPCHAT_PROXY=http://127.0.0.1:3128
+
+Sample Successful Call
+----------------------
+    $ hipchat.pl -message 'Hello World!' -colour green
+    Hipchat notification posted successfully.
+
+Sample Unsuccessful Call (bad token)
+------------------------------------
+    $ hipchat.pl -token abd -message 'Hello World!' -colour green
+    Hipchat notification failed!
+    401 Unauthorized

--- a/hipchat.pl
+++ b/hipchat.pl
@@ -76,7 +76,7 @@ GetOptions( "room=s"         => \$optionRoom,
             "host=s"         => \$optionHipchatHost,
             "notify=s"       => \$optionNotify,
             "colour|color=s" => \$optionColour,
-            "debug=s"        => \$optionDebug);
+            "debug=s"        => \$optionDebug) || die ("$usage\n");;
 
 ##############################
 ## VERIFY OPTIONS

--- a/hipchat.pl
+++ b/hipchat.pl
@@ -27,19 +27,21 @@ my $usage = "This script will send a notification to hipchat.\n
 \t\thipchat.pl -room \"test\" -token \"abc\" -message \"Hello World!\" 
 \n\tFull Example:
 \t\thipchat.pl -room \"test\" -token \"abc\" -message \"Hello World!\" -type text -api v2 -notify true -colour green -proxy http://127.0.0.1:3128
+\n\tIf set, the following environment variables will be used for default values, but will be overridden by command line parameters:
+\t\tHIPCHAT_ROOM, HIPCHAT_TOKEN, HIPCHAT_FROM, HIPCHAT_API, HIPCHAT_PROXY, HIPCHAT_HOST
 \n";
 
-my $optionRoom         = "";
-my $optionToken        = "";
+my $optionRoom         = $ENV{HIPCHAT_ROOM} || "";
+my $optionToken        = $ENV{HIPCHAT_TOKEN} || "";
 my $optionMessage      = "";
-my $optionFrom         = "";
+my $optionFrom         = $ENV{HIPCHAT_FROM} || "";
 my $optionType         = "";
-my $optionAPI          = "";
-my $optionProxy        = "";
+my $optionAPI          = $ENV{HIPCHAT_API} || "";
+my $optionProxy        = $ENV{HIPCHAT_PROXY} || "";
 my $optionNotify       = "";
 my $optionColour       = "";
-my $optionDebug        = "";
-my $optionHipchatHost  = "https://api.hipchat.com";
+my $optionDebug        = $ENV{HIPCHAT_DEBUG} || "";
+my $optionHipchatHost  = $ENV{HIPCHAT_HOST} || "https://api.hipchat.com";
 my $hipchat_url        = "";
 my $hipchat_json       = "";
 my $message_limit      = "";
@@ -258,7 +260,7 @@ else
 }
 
 #Print some debug info if requested.
-if ($optionDebug ne "")
+if ($optionDebug)
 {
    print $response->decoded_content . "\n";
    print "URL            = $hipchat_url\n";

--- a/hipchat.pl
+++ b/hipchat.pl
@@ -22,6 +22,7 @@ my $usage = "This script will send a notification to hipchat.\n
 \t\t-colour    (Optional) Message colour (y|r|g|p|g|random)  Example: '-colour \"green\"'                (default: yellow)
 \t\t-from      (Optional) Name message is to be sent from.   Example: '-from \"Test\"'                   (only used with APIv1)
 \t\t-proxy     (Optional) Network proxy to use.              Example: '-proxy \"http://127.0.0.1:3128\"'
+\t\t-host      (Optional) HipChat server to use.             Example: '-host \"https://hipchat.company.net\"'
 \n\tBasic Example:
 \t\thipchat.pl -room \"test\" -token \"abc\" -message \"Hello World!\" 
 \n\tFull Example:
@@ -38,7 +39,7 @@ my $optionProxy        = "";
 my $optionNotify       = "";
 my $optionColour       = "";
 my $optionDebug        = "";
-my $hipchat_host       = "";
+my $optionHipchatHost  = "https://api.hipchat.com";
 my $hipchat_url        = "";
 my $hipchat_json       = "";
 my $message_limit      = "";
@@ -57,7 +58,6 @@ my $response           = "";
 my $exit_code          = "";
 
 #Set some options statically.
-$hipchat_host          = "https://api.hipchat.com";
 $default_colour        = "yellow";
 $default_API           = "v2";
 $default_type          = "text";
@@ -71,6 +71,7 @@ GetOptions( "room=s"         => \$optionRoom,
             "type=s"         => \$optionType,
             "api=s"          => \$optionAPI,
             "proxy=s"        => \$optionProxy,
+            "host=s"         => \$optionHipchatHost,
             "notify=s"       => \$optionNotify,
             "colour|color=s" => \$optionColour,
             "debug=s"        => \$optionDebug);
@@ -212,7 +213,7 @@ if ($optionProxy ne "")
 #Submit the notification based on API version
 if ($optionAPI eq "v1")
 {
-   $hipchat_url = "$hipchat_host\/$optionAPI\/rooms/message";
+   $hipchat_url = "$optionHipchatHost\/$optionAPI\/rooms/message";
 
    $response = $ua->post($hipchat_url, {
          auth_token=> $optionToken,
@@ -227,7 +228,7 @@ if ($optionAPI eq "v1")
 } 
 elsif ($optionAPI eq "v2")
 {
-   $hipchat_url = "$hipchat_host\/$optionAPI\/room/$optionRoom/notification?auth_token=$optionToken";
+   $hipchat_url = "$optionHipchatHost\/$optionAPI\/room/$optionRoom/notification?auth_token=$optionToken";
    $hipchat_json = encode_json({
       color    => $optionColour,
       message  => $optionMessage,


### PR DESCRIPTION
Added a parameter to allow targeting a private Hipchat server endpoint. Also, updated usage message:

```
   -host      (Optional) HipChat server to use.             Example: '-host "https://hipchat.company.net"'
```

Also, allow configuration to be set in the environment per [The Twelve-Factor App](http://12factor.net/config) methodology.

Also, die with usage message, so (-help, -usage) will not have side effects.
