### PR TITLE
Allow messages to be sent to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Sample Script Output
 
     Usage:
         -room      Hipchat room name or ID.                      Example: '-room "test"'
+        -user      Hipchat user @name, email or ID. (v2 only)    Example: '-user "@TestUser"'
         -token     Hipchat Authentication token.                 Example: '-token "abc"'
         -message   Message to be sent to room.                   Example: '-message "Hello World!"'
         -type      (Optional) Hipchat message type (text|html).  Example: '-type "text"'                   (default: text)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sample Script Output
         -token     Hipchat Authentication token.                 Example: '-token "abc"'
         -message   Message to be sent to room.                   Example: '-message "Hello World!"'
         -type      (Optional) Hipchat message type (text|html).  Example: '-type "text"'                   (default: text)
-        -API       (Optional) Hipchat API Version. (v1|v2).      Example: '-type "v2"'                     (default: v2)
+        -API       (Optional) Hipchat API Version. (v1|v2).      Example: '-api "v2"'                      (default: v2)
         -notify    (Optional) Message will trigger notification. Example: '-notify "true"'                 (default: false)
         -colour    (Optional) Message colour (y|r|g|p|g|random)  Example: '-colour "green"'                (default: yellow)
         -from      (Optional) Name message is to be sent from.   Example: '-from "Test"'                   (only used with APIv1)

--- a/hipchat.pl
+++ b/hipchat.pl
@@ -17,14 +17,14 @@ my $usage = "This script will send a notification to hipchat.\n
 \t\t-token     Hipchat Authentication token.                 Example: '-token \"abc\"'
 \t\t-message   Message to be sent to room.                   Example: '-message \"Hello World!\"'
 \t\t-type      (Optional) Hipchat message type (text|html).  Example: '-type \"text\"'                   (default: text)
-\t\t-API       (Optional) Hipchat API Version. (v1|v2).      Example: '-type \"v2\"'                     (default: v2)
+\t\t-API       (Optional) Hipchat API Version. (v1|v2).      Example: '-api \"v2\"'                      (default: v2)
 \t\t-notify    (Optional) Message will trigger notification. Example: '-notify \"true\"'                 (default: false)
 \t\t-colour    (Optional) Message colour (y|r|g|p|g|random)  Example: '-colour \"green\"'                (default: yellow)
 \t\t-from      (Optional) Name message is to be sent from.   Example: '-from \"Test\"'                   (only used with APIv1)
 \t\t-proxy     (Optional) Network proxy to use.              Example: '-proxy \"http://127.0.0.1:3128\"'
 \t\t-host      (Optional) HipChat server to use.             Example: '-host \"https://hipchat.company.net\"'
 \n\tBasic Example:
-\t\thipchat.pl -room \"test\" -token \"abc\" -message \"Hello World!\" 
+\t\thipchat.pl -room \"test\" -token \"abc\" -message \"Hello World!\"
 \n\tFull Example:
 \t\thipchat.pl -room \"test\" -token \"abc\" -message \"Hello World!\" -type text -api v2 -notify true -colour green -proxy http://127.0.0.1:3128
 \n\tIf set, the following environment variables will be used for default values, but will be overridden by command line parameters:
@@ -96,14 +96,14 @@ if ($optionToken eq "")
    die ("$usage\n");
 }
 
-if ($optionMessage eq "") 
+if ($optionMessage eq "")
 {
    print "\tYou must specify a message to post!\n";
    die ($usage);
 }
 
 #Check that the API version is valid.
-if ($optionAPI eq "") 
+if ($optionAPI eq "")
 {
    $optionAPI = $default_API;
 }
@@ -123,7 +123,7 @@ if (!$api_is_valid)
 }
 
 #Check that the From name exists if using API v1.
-if ($optionFrom eq "") 
+if ($optionFrom eq "")
 {
    if ($optionAPI eq "v1")
    {
@@ -136,11 +136,11 @@ if ($optionFrom eq "")
 if (length($optionMessage) > $message_limit)
 {
    print "\tMessage must be $message_limit characters or less!\n";
-   die ("$usage\n");   
+   die ("$usage\n");
 }
 
 #Check that the message type is valid.
-if ($optionType eq "") 
+if ($optionType eq "")
 {
    $optionType = $default_type;
 }
@@ -177,7 +177,7 @@ else
 }
 
 #Check that the colour is valid.
-if ($optionColour eq "") 
+if ($optionColour eq "")
 {
    $optionColour = $default_colour;
 }
@@ -227,7 +227,7 @@ if ($optionAPI eq "v1")
          color => $optionColour,
          format => 'json',
       });
-} 
+}
 elsif ($optionAPI eq "v2")
 {
    $hipchat_url = "$optionHipchatHost\/$optionAPI\/room/$optionRoom/notification?auth_token=$optionToken";


### PR DESCRIPTION
Implement -user option to allow messages to be sent to users instead of rooms.  Only works for v2 because I couldn't find the docs for v1

Also fix a minor typo for --api in the help